### PR TITLE
Finder item integration

### DIFF
--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -1,33 +1,23 @@
-
-#find_all uses find_by
+require 'pry'
 
 module Finder
-
-  def find_by(class, attribute)
-    # case class
-    # when "merchant"
-    #   => {:id = 12345, :name => "Turing School"}
-    # 
-    # when "item"
-    #   => {:id = 1, 
-    #       :name => "Pencil", 
-    #       :description => "You can use it to write things",
-    #       ...}
-    #
-
+  
+  def find_by_id(id)
+    @csv.keep_if do |key, value|      
+      key == id
+    end
   end
 
-
-  def find_all_by(class, attribute)
-    # case class
-    # 
-    # calls find_by to return all chosen
-    #
-    #
-    #
-    #
-    #
-    #    
-
+  def find_by_name(name)
+    all.keep_if do |entry|      
+      entry.name == name
+    end
   end
+
+  def find_all_by_name(name)
+    all.keep_if do |entry|      
+      entry.name == name
+    end
+  end
+  
 end

--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -2,48 +2,13 @@ require 'pry'
 
 module Finder
   
-  def find_by_id(id)
-    @csv.keep_if do |key, value|      
-      key == id
+  def find_by(repo, id)
+    repo.keep_if do |entry|      
+      entry.id == id
     end
   end
 
-  def find_by_name(name)
-    all.keep_if do |entry|      
-      entry.name == name
-    end
-  end
+  
 
-  def find_all_by_name(name)
-    all.keep_if do |entry|      
-      entry.name == name
-    end
-  end
 
-  def find_highest_id
-    all.max_by do |entry|
-      entry.id
-    end
-  end
-
-  def create(attributes)
-    new_id = find_highest_id.id + 1
-    new_item_attributes = {
-      :id           => new_id,
-      :name         => attributes[:name],
-      :description  => attributes[:description],
-      :unit_price   => attributes[:unit_price],
-      :created_at   => Time.now,
-      :updated_at   => Time.now,
-      :merchant_id  => 2
-    }
-    return Item.new(new_item_attributes)
-    # next, write to csv
-  end
-
-  def delete(id)
-    find_by_id(id)
-    binding.pry
-    #return @all with chosen entry deleted
-  end
 end

--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -40,4 +40,10 @@ module Finder
     return Item.new(new_item_attributes)
     # next, write to csv
   end
+
+  def delete(id)
+    find_by_id(id)
+    binding.pry
+    #return @all with chosen entry deleted
+  end
 end

--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -19,5 +19,11 @@ module Finder
       entry.name == name
     end
   end
+
+  def find_highest_id
+    all.max_by do |entry|
+      entry.id
+    end
+  end
   
 end

--- a/lib/finder.rb
+++ b/lib/finder.rb
@@ -25,5 +25,19 @@ module Finder
       entry.id
     end
   end
-  
+
+  def create(attributes)
+    new_id = find_highest_id.id + 1
+    new_item_attributes = {
+      :id           => new_id,
+      :name         => attributes[:name],
+      :description  => attributes[:description],
+      :unit_price   => attributes[:unit_price],
+      :created_at   => Time.now,
+      :updated_at   => Time.now,
+      :merchant_id  => 2
+    }
+    return Item.new(new_item_attributes)
+    # next, write to csv
+  end
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -15,6 +15,7 @@ class Item
   def initialize(hash)
     # -- Read Only --
     @id = hash[:id]
+    
     @created_at = hash[:created_at]
     @merchant_id = hash[:merchant_id]
     # -- Accessible --

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -6,9 +6,10 @@ require 'pry'
 
 require_relative 'item'
 require_relative 'csv_parse'
-
+require './lib/finder'
 
 class ItemRepository
+  include Finder
 
   attr_reader :all
 
@@ -34,6 +35,13 @@ class ItemRepository
     # provided are all needed for the Item object
     value.each { |col, data| hash[col] = data }
     return hash
+  end
+
+  #overrides module
+  def find_by_id(id)
+    all.keep_if do |item|      
+      item.id == id.to_i
+    end
   end
 
 end

--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -10,12 +10,12 @@ require_relative 'csv_parse'
 
 class ItemRepository
 
-  attr_reader :items
+  attr_reader :all
 
   def initialize(path)
     @csv = CSVParse.create_repo(path)
     # @headers = [:created_at, :merchant_id, :name, :description, :unit_price, :updated_at]
-    @items = []
+    @all = []
     make_items
   end
 
@@ -23,9 +23,9 @@ class ItemRepository
     @csv.each { |key, value|
       hash = make_hash(key, value)
       item = Item.new(hash)
-      @items << item
+      @all << item
     }
-    @items.flatten!
+    @all.flatten!
   end
 
   def make_hash(key, value)

--- a/test/item_repository_test.rb
+++ b/test/item_repository_test.rb
@@ -60,7 +60,17 @@ class ItemRepositoryTest < Minitest::Test
     assert_equal new_hash, @repo.make_hash(@key, @value)
   end
 
+  def test_it_can_find_all
+    assert_equal 1367, @repo.all.count
+  end
 
+  def test_it_can_find_by_id
+    # well, it works
+    assert_equal 263395617, @repo.find_by_id("263395617").first.id
+  end
 
+  def test_it_can_find_all_by_name
+    assert_equal [@first_item], @repo.find_all_by_name("510+ RealPush Icon Set")
+  end
 
 end

--- a/test/item_repository_test.rb
+++ b/test/item_repository_test.rb
@@ -77,4 +77,29 @@ class ItemRepositoryTest < Minitest::Test
     assert_equal 263567474, @repo.find_highest_id.id
   end
 
+  def test_it_can_create_new_merchant_instance_from_attribute_hash
+    new_item = {
+      :id             => 0,
+      :name           => "511+ RealPush Icon Set",
+      :description    => "You&#39;ve got a total socialmedia iconset!", # NOTE - excerpt!
+      :unit_price     => BigDecimal(10.99,4),
+      :created_at     => Time.now,
+      :updated_at     => Time.now,
+      :merchant_id    => 2
+    }
+
+    expected = Item.new({
+      :id             => 263567475,
+      :name           => "511+ RealPush Icon Set",
+      :description    => "You&#39;ve got a total socialmedia iconset!",
+      :unit_price     => BigDecimal(10.99,4),
+      :created_at     => Time.now,
+      :updated_at     => Time.now,
+      :merchant_id    =>2
+    })
+    
+    assert_equal expected.id, @repo.create(new_item).id
+    
+  end
+
 end

--- a/test/item_repository_test.rb
+++ b/test/item_repository_test.rb
@@ -73,4 +73,8 @@ class ItemRepositoryTest < Minitest::Test
     assert_equal [@first_item], @repo.find_all_by_name("510+ RealPush Icon Set")
   end
 
+  def test_it_can_find_highest_id
+    assert_equal 263567474, @repo.find_highest_id.id
+  end
+
 end

--- a/test/item_repository_test.rb
+++ b/test/item_repository_test.rb
@@ -17,9 +17,9 @@ class ItemRepositoryTest < Minitest::Test
     @repo = ItemRepository.new(@path)
 
     # -- First Item's information --
-    @first_item = @repo.items[0]
+    @first_item = @repo.all[0]
     # NOTE - The description is only an except.
-    # NOTE - DO NOT try to match the description value (@repo.items[0].description)
+    # NOTE - DO NOT try to match the description value (@repo.all[0].description)
     @headers = [:id, :created_at, :merchant_id, :name, :description, :unit_price, :updated_at]
     # --- CSVParse created hash set ---
     @key = :"263395237"
@@ -40,9 +40,9 @@ class ItemRepositoryTest < Minitest::Test
   end
 
   def test_it_makes_and_gets_items
-    assert_instance_of Array, @repo.items
-    assert_instance_of Item,  @repo.items[0]
-    assert_instance_of Item,  @repo.items[1000]
+    assert_instance_of Array, @repo.all
+    assert_instance_of Item,  @repo.all[0]
+    assert_instance_of Item,  @repo.all[1000]
   end
 
   def test_it_makes_items

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -41,6 +41,10 @@ class MerchantRepositoryTest < Minitest::Test
       assert_equal "Shopin1901", merch[0].name
     end
 
-    
+    def test_delete_returns_modified_array
+      @repo.delete("12334105")
+      
+
+    end
     
 end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -41,6 +41,6 @@ class MerchantRepositoryTest < Minitest::Test
       assert_equal "Shopin1901", merch[0].name
     end
 
-
-
+    
+    
 end


### PR DESCRIPTION
Updates ItemRepo to use Finder Methods

- require/include Finder
- attr_reader :all now holds loaded array for any repo
- tests 1:1 (where applicable)
- override method for find_by_id because of the way the objects are stored.